### PR TITLE
Inifinite Scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "postcss": "8.4.40",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-infinite-scroll-component": "^6.1.0",
         "react-markdown": "9.0.1",
         "recoil": "^0.7.7",
         "tailwind-merge": "^2.4.0",
@@ -7756,6 +7757,17 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-infinite-scroll-component": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz",
+      "integrity": "sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==",
+      "dependencies": {
+        "throttle-debounce": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8838,6 +8850,14 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postcss": "8.4.40",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-markdown": "9.0.1",
     "recoil": "^0.7.7",
     "tailwind-merge": "^2.4.0",

--- a/src/components/story/story-list.tsx
+++ b/src/components/story/story-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@nextui-org/button';
+import InfiniteScroll from 'react-infinite-scroll-component';
 import clsx from 'clsx';
 import { Story } from '@/app/types';
 import { StoryItem } from '@/components/story/story-item';
@@ -13,11 +13,11 @@ interface StoryListProps {
 }
 
 /**
- * @description Shows all the stories in addition to a fetch more button.
+ * @description Shows all the stories with infinite scroll to fetch more items.
  */
 export function StoryList(props: StoryListProps) {
   const { className } = props;
-  const { fetchMore, stories } = useStories();
+  const { fetchMore, hasMore, stories } = useStories(); // Make sure useStories hook returns hasMore
   const { starredStories } = useStarredStories();
   const { isStarredSelected } = useMenuOptionStarred();
 
@@ -27,18 +27,23 @@ export function StoryList(props: StoryListProps) {
 
   return (
     <div className={clsx('flex flex-col gap-10', className)}>
-      <div className="flex flex-col gap-6">
-        {displayedStories.map((story, index) => (
-          <StoryItem key={index} story={story} index={index} />
-        ))}
-      </div>
-      {!isStarredSelected && (
-        <div className="ml-14 mb-8">
-          <Button color="primary" radius="none" onPress={fetchMore}>
-            Show More
-          </Button>
+      <InfiniteScroll
+        dataLength={displayedStories.length}
+        next={fetchMore}
+        hasMore={hasMore}
+        loader={null}
+        endMessage={
+          <p className="py-10 ">
+            <b>Yay! You have seen it all! 🎉</b>
+          </p>
+        }
+      >
+        <div className="flex flex-col gap-6">
+          {displayedStories.map((story, index) => (
+            <StoryItem key={index} story={story} index={index} />
+          ))}
         </div>
-      )}
+      </InfiniteScroll>
     </div>
   );
 }

--- a/src/hooks/use-stories.ts
+++ b/src/hooks/use-stories.ts
@@ -12,8 +12,12 @@ export default function useStories() {
 
   useEffect(() => {
     async function fetchStories() {
+      // We will only fetch a max of 11 pages. From trial and error, it seems that
+      // the Hacker News api doesn't return anything after page 11.
+      const pageToFetch = Math.min(page, 11);
+
       const response = await fetch(
-        `https://api.hnpwa.com/v0/news/${page}.json`,
+        `https://api.hnpwa.com/v0/news/${pageToFetch}.json`,
       );
       const data = await response.json();
 
@@ -25,6 +29,7 @@ export default function useStories() {
 
   return {
     fetchMore: () => setPage(page + 1),
+    hasMore: page < 11,
     stories,
   };
 }


### PR DESCRIPTION
# Overview

This PR does the following:

1. Adds inifinite scrolling to the story list. It caps out at 11 pages because after that it seem that Hacker News doesn't return anything.